### PR TITLE
Add canu runner

### DIFF
--- a/bin/configure.pl
+++ b/bin/configure.pl
@@ -710,6 +710,13 @@ assemblers:
      contig_output: __TMPDIR__/celera/output/9-terminator/BugBuilder.ctg.fasta
      scaffold_output: __TMPDIR__/celera/output/9-terminator/BugBuilder.scf.fasta
      downsample_reads: 0
+   - name: canu
+     create_dir: 0
+     min_length: 300
+     command_se: __BUGBUILDER_BIN__/run_canu --fastq_long __LONG_FASTQ__ --tmpdir __TMPDIR__ --category __CATEGORY__ --platform __PLATFORM__ --genome_size __GENOME_SIZE__
+     contig_output: __TMPDIR__/assembly/BugBuilder.contigs.fasta
+     downsample_reads: 0
+     default_args: stopOnReadQuality=false
    - name: PBcR
      create_dir: 1
      min_length: 500

--- a/bin/run_canu
+++ b/bin/run_canu
@@ -1,0 +1,124 @@
+#!/bin/env perl
+
+######################################################################
+#
+# $HeadURL: https://bss-srv4.bioinformatics.ic.ac.uk/svn/BugBuilder/trunk/bin/run_celera $
+# $Author: nickp60 $
+# $Revision: 179 $
+# $Date: 2017-11-13 10:32:17 +0000 (Mon, 13 Nov 2017) $
+#
+# Wrapper for canu assembler to permit use via BugBuilder assembly stage
+#
+# This file is part of BugBuilder (https://github.com/jamesabbott/BugBuilder)
+# and is distributed under the Artistic License 2.0 - see accompanying LICENSE
+# file for details
+
+#
+######################################################################
+
+=pod
+
+=head1 NAME
+
+run_canu
+
+=head1 SYNOPSIS
+
+run_canu --tmpdir BugBuilder_working_directory --fastq1 read1.fastq --fastq2 read2.fastq
+--category [assembler_category] [--insert_size insertsize] [--insert-stddev stddev] [--help]
+
+=head1 DESCRIPTION
+
+Wrapper for Canu WGS assembler. Canu requires inputs in it's own FRG format, hence we need to
+initially convert our fastq files, before running the assembler
+
+=head1 REQUIRED ARGUMEMNTS
+
+=over 4
+
+=item B<tmpdir>: BugBuilder working directory, containing unscaffolded contigs.fasta file
+
+=item B<long_fastq>: Fastq file from PacBio or Nanopore run
+
+=item B<category>: Category of assembly i.e. long_illumina, 454_IonTorrent
+
+=item B<platform>: platform of assembly i.e. PacBio or MinION
+
+=item B<genome_size>: Estimated size of genome
+
+=back
+
+=head1 OPTIONAL ARGUMENTS
+
+=over 4
+
+=item B<help>: display short help text
+
+=item B<man>: display full documentation
+
+=back
+
+=head1 REPORTING BUGS
+
+Please report any bugs/issues via github:
+https://github.com/jamesabbott/BugBuilder/issues/new
+
+=head1 AUTHOR - James Abbott and Nick Waters
+
+Email j.abbott@imperial.ac.uk and nickp60@gmail.com
+
+=cut
+
+use warnings;
+use strict;
+
+use FindBin;
+use YAML::XS qw(LoadFile);
+use Getopt::Long;
+use Pod::Usage;
+use Carp qw(croak cluck);
+use Bio::SeqIO;
+
+{
+
+    my $config = LoadFile("$FindBin::Bin/../etc/BugBuilder.yaml");
+    my ( $help, $man, $long_fastq, $category, $platform, $tmpdir, $genome_size );
+
+    my $result = GetOptions(
+                             'tmpdir=s'        => \$tmpdir,
+                             'long_fastq:s'    => \$long_fastq,
+                             'category=s'      => \$category,
+                             'platform=s'      => \$platform,
+			     'genome_size:s'   => \$genome_size,
+                             'help'            => \$help,
+                             'man'             => \$man,
+                           );
+
+    croak "\nUnknown argument: @ARGV" if "@ARGV";
+    pod2usage( verbose => 2 ) if ($man);
+    pod2usage( verbose => 1 )
+      if ( $help || !$tmpdir || !$long_fastq || !$category || !$genome_size);
+
+    croak "\n$long_fastq does not exist" unless ( -e $long_fastq );
+    croak "Invalid plaftorm: $category"
+      unless ( $category eq 'long');
+
+    # chdir "$tmpdir/canu" or croak "Could not chdir to $tmpdir/canu: $!";
+
+    my $readtype;
+    # temporarily, treat all as raw reads
+    if (lc($platform) eq 'minion') {
+	$readtype = "-nanopore-raw";	
+    } elsif (lc($platform) eq 'pacbio') {
+	$readtype = '-pacbio-raw';
+    } elsif (0) {
+	die ("categpry must be either PacBio or MinION");
+    }
+    my $cmd = $config->{'canu_dir'} . "canu -p BugBuilder -genomeSize=$genome_size -d ./assembly $readtype $long_fastq ";
+
+    print "running $cmd...\n";
+    system($cmd) == 0 or croak " Error executing $cmd: $! ";
+
+    exit(0);
+
+}

--- a/bin/run_canu
+++ b/bin/run_canu
@@ -94,7 +94,8 @@ use Bio::SeqIO;
                              'man'             => \$man,
                            );
 
-    croak "\nUnknown argument: @ARGV" if "@ARGV";
+    # croak "\nUnknown argument: @ARGV" if "@ARGV";
+    my $assembler_args = join(" ", @ARGV);
     pod2usage( verbose => 2 ) if ($man);
     pod2usage( verbose => 1 )
       if ( $help || !$tmpdir || !$long_fastq || !$category || !$genome_size);
@@ -114,7 +115,7 @@ use Bio::SeqIO;
     } elsif (0) {
 	die ("categpry must be either PacBio or MinION");
     }
-    my $cmd = $config->{'canu_dir'} . "canu -p BugBuilder -genomeSize=$genome_size -d ./assembly $readtype $long_fastq ";
+    my $cmd = $config->{'canu_dir'} . "canu -p BugBuilder -genomeSize=$genome_size -d ./assembly $readtype $long_fastq $assembler_args";
 
     print "running $cmd...\n";
     system($cmd) == 0 or croak " Error executing $cmd: $! ";

--- a/etc/BugBuilder.yaml
+++ b/etc/BugBuilder.yaml
@@ -82,7 +82,7 @@ assembler_categories:
       - sspace
   - name: 'long_illumina'
     min_length:  75
-    max_length: 250
+    max_length: 303
     single_fastq: 'optional'
     paired_fastq: 'optional'
     platforms:
@@ -109,13 +109,13 @@ assembler_categories:
       - SIS
   - name: 'long'
     min_length: 500
-    max_length: 50000
+    max_length: 5000000
     long_fastq: 'required'
     platforms:
       - 'PacBio'
       - 'MinION'
     assemblers: 
-      - PBcR
+      - canu
   - name: 'hybrid'
     min_length: 75
     max_length: 50000
@@ -155,6 +155,13 @@ assemblers:
      contig_output: __TMPDIR__/celera/output/9-terminator/BugBuilder.ctg.fasta
      scaffold_output: __TMPDIR__/celera/output/9-terminator/BugBuilder.scf.fasta
      downsample_reads: 0
+   - name: canu
+     create_dir: 0
+     min_length: 300
+     command_se: __BUGBUILDER_BIN__/run_canu --fastq_long __LONG_FASTQ__ --tmpdir __TMPDIR__ --category __CATEGORY__ --platform __PLATFORM__ --genome_size __GENOME_SIZE__
+     contig_output: __TMPDIR__/assembly/BugBuilder.contigs.fasta
+     downsample_reads: 0
+     default_args: stopOnReadQuality=false
    - name: PBcR
      create_dir: 1
      min_length: 500

--- a/etc/package_info.yaml
+++ b/etc/package_info.yaml
@@ -65,6 +65,17 @@ packages:
       version:
         - '1.0-r31'
 
+    - name: 'canu'
+      download_url: 'https://github.com/marbl/canu/archive/v1.6.tar.gz'
+      inst_source: 'v1.6.tar.gz'
+      build_cmd: 'cd __BBDIR__/canu-1.6/src; make -j 8 2>&1; mv -v canu __PACKDIR__/bin/seqtk 2>&1'
+      key: 'canu_dir'
+      bin_dir: '/bin'
+      binary: 'canu'
+      version_test: "__BINARY__ 2>&1|grep Version|awk '{print $2}'"
+      version:
+        - '1.6'
+
     - name: 'samtools'
       binary:  'samtools'
       version_test: "__BINARY__ 2>&1|grep Version|cut -d' ' -f 2"


### PR DESCRIPTION
I have added a script to run the Canu assembler; I have tested the script by itself, and it seems to be functional.  Notes:
- TODO: determine if long reads are raw or corrected
- check to ensure the assembler-args get properly passed;  I couldn't tell how assembler_args got passed in the run_abyss script, so I just set assembler-args to `@ARGV` in run_canu.  Is that ok?
- TODO: test configure.pl for downloading/building canu